### PR TITLE
Update FiasController.php

### DIFF
--- a/console/controllers/FiasController.php
+++ b/console/controllers/FiasController.php
@@ -28,7 +28,7 @@ class FiasController extends \yii\console\Controller
 {
     public $region;
 
-    public function options()
+    public function options($actionID)
     {
         return [
             'region',


### PR DESCRIPTION
PHP Strict Warning 'yii\base\ErrorException' with message 'Declaration of ejen\fias\console\controllers\FiasController::options() should be compatible with yii\console\Controller::options($actionID)'
